### PR TITLE
add optional arguments and basic initializer list support

### DIFF
--- a/include/dooc/named_args_tuple.hpp
+++ b/include/dooc/named_args_tuple.hpp
@@ -648,6 +648,7 @@ public:
   using value_type = T;
   using reference = T const &;
   using const_reference = T const &;
+  constexpr named_initializer_list_t() = default;
   constexpr explicit(false)
       named_initializer_list_t(std::initializer_list<T> list)
       : data_(list.begin(), list.end()) {}

--- a/include/dooc/named_args_tuple.hpp
+++ b/include/dooc/named_args_tuple.hpp
@@ -644,7 +644,7 @@ template <typename T> class named_initializer_list_t {
 public:
   using iterator = T const *;
   using const_iterator = T const *;
-  using size_type = span_t::size_type;
+  using size_type = typename span_t::size_type;
   using value_type = T;
   using reference = T const &;
   using const_reference = T const &;
@@ -659,9 +659,9 @@ public:
   }
   constexpr size_type size() const noexcept { return data_.size(); }
 
-  template <std::constructible_from<iterator, iterator> T>
-  constexpr operator T() const {
-    return T(begin(), end());
+  template <std::constructible_from<iterator, iterator> T2>
+  constexpr operator T2() const {
+    return T2(begin(), end());
   }
 };
 

--- a/include/dooc/type_tag.hpp
+++ b/include/dooc/type_tag.hpp
@@ -3,14 +3,17 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef DOOC_WIP_HRP_AND_AP_PUBLIC_INCLUDE_DOOC_TYPE_TAG_HPP
-#define DOOC_WIP_HRP_AND_AP_PUBLIC_INCLUDE_DOOC_TYPE_TAG_HPP
+#ifndef DOOC_NP_DOOC_TYPE_TAG_HPP
+#define DOOC_NP_DOOC_TYPE_TAG_HPP
 
 #include <array>
 #include <iterator>
 #include <string_view>
 
 namespace dooc {
+template <typename... Ts>
+constexpr inline void unused(Ts const &...) noexcept {}
+
 template <std::size_t tN> struct template_string {
   std::array<char, tN - 1> data_;
   using size_type = std::size_t;


### PR DESCRIPTION
Initializer lists are a bit strange, not perfectly straight forward to support. PR uses the 'iterator' constructor instead of trying to return an initializer list (std::initializer_list has some special rules regarding deduction as a return argument that makes it a little bit trickier.)